### PR TITLE
Changes to KLScrollSelect to work on iOS 5

### DIFF
--- a/KLScrollSelect/KLScrollSelect/KLScrollSelect.m
+++ b/KLScrollSelect/KLScrollSelect/KLScrollSelect.m
@@ -332,48 +332,52 @@
 
 -(void) willMoveToSuperview:(UIView *)newSuperview {
     [super willMoveToSuperview:newSuperview];
-    self.backgroundColor = [UIColor clearColor];
-    self.image = [[UIImageView alloc] initWithFrame: CGRectMake( kDefaultCellImageEdgeInset.left,
-                                                                kDefaultCellImageEdgeInset.top,
-                                                                self.frame.size.width - (kDefaultCellImageEdgeInset.left + kDefaultCellImageEdgeInset.right),
-                                                                self.frame.size.height - (kDefaultCellImageEdgeInset.top + kDefaultCellImageEdgeInset.bottom))];
-    [self.image.layer setBorderWidth: 1.0];
-    [self.image.layer setBorderColor: [UIColor colorWithRed: 1
-                                                      green: 1
-                                                       blue: 1
-                                                      alpha: 0.4].CGColor];
-    [self.image.layer setCornerRadius:6.0];
-    
-    [self.image setClipsToBounds:YES];
-    
-    [self addSubview: self.image];
-    
-    CGFloat labelHeight = 20;
-    
-    self.label = [[UILabel alloc] initWithFrame: CGRectMake(self.image.frame.origin.x,
-                                                            self.image.frame.size.height - labelHeight*2,
-                                                            self.image.frame.size.width,
-                                                            labelHeight)];
-    
-    [self.label setBackgroundColor:[UIColor clearColor]];
-    [self.label setTextColor:[UIColor whiteColor]];
-    [self.label setTextAlignment:NSTextAlignmentCenter];
-    [self.label setFont:[UIFont systemFontOfSize: 15]];
-    [self.image addSubview:self.label];
-    
-    self.subLabel = [[UILabel alloc] initWithFrame: CGRectMake(self.image.frame.origin.x,
-                                                               self.image.frame.size.height - labelHeight,
-                                                               self.image.frame.size.width,
-                                                               labelHeight)];
-    
-    [self.subLabel setBackgroundColor:[UIColor clearColor]];
-    [self.subLabel setTextColor:[UIColor whiteColor]];
-    [self.subLabel setTextAlignment:NSTextAlignmentCenter];
-    [self.subLabel setFont:[UIFont boldSystemFontOfSize: 15]];
-    [self.image addSubview:self.subLabel];
-    
-    [self.layer setShouldRasterize:YES];
-    [self.layer setRasterizationScale: [UIScreen mainScreen].scale];
+    // On iOS 5 willMoveToSuperview method always gets called, so by checking existence of self.image ,
+    // we prevent imageView initialization of reused cells otherwise we face with low performance while scrolling
+    if (self.image == nil) {
+        self.backgroundColor = [UIColor clearColor];
+        self.image = [[UIImageView alloc] initWithFrame: CGRectMake( kDefaultCellImageEdgeInset.left,
+                                                                    kDefaultCellImageEdgeInset.top,
+                                                                    self.frame.size.width - (kDefaultCellImageEdgeInset.left + kDefaultCellImageEdgeInset.right),
+                                                                    self.frame.size.height - (kDefaultCellImageEdgeInset.top + kDefaultCellImageEdgeInset.bottom))];
+        [self.image.layer setBorderWidth: 1.0];
+        [self.image.layer setBorderColor: [UIColor colorWithRed: 1
+                                                          green: 1
+                                                           blue: 1
+                                                          alpha: 0.4].CGColor];
+        [self.image.layer setCornerRadius:6.0];
+        
+        [self.image setClipsToBounds:YES];
+        
+        [self addSubview: self.image];
+        
+        CGFloat labelHeight = 20;
+        
+        self.label = [[UILabel alloc] initWithFrame: CGRectMake(self.image.frame.origin.x,
+                                                                self.image.frame.size.height - labelHeight*2,
+                                                                self.image.frame.size.width,
+                                                                labelHeight)];
+        
+        [self.label setBackgroundColor:[UIColor clearColor]];
+        [self.label setTextColor:[UIColor whiteColor]];
+        [self.label setTextAlignment:NSTextAlignmentCenter];
+        [self.label setFont:[UIFont systemFontOfSize: 15]];
+        [self.image addSubview:self.label];
+        
+        self.subLabel = [[UILabel alloc] initWithFrame: CGRectMake(self.image.frame.origin.x,
+                                                                   self.image.frame.size.height - labelHeight,
+                                                                   self.image.frame.size.width,
+                                                                   labelHeight)];
+        
+        [self.subLabel setBackgroundColor:[UIColor clearColor]];
+        [self.subLabel setTextColor:[UIColor whiteColor]];
+        [self.subLabel setTextAlignment:NSTextAlignmentCenter];
+        [self.subLabel setFont:[UIFont boldSystemFontOfSize: 15]];
+        [self.image addSubview:self.subLabel];
+        
+        [self.layer setShouldRasterize:YES];
+        [self.layer setRasterizationScale: [UIScreen mainScreen].scale];
+    }
 }
 
 @end

--- a/KLScrollSelectDemo/KLScrollSelectDemo/KLViewController.m
+++ b/KLScrollSelectDemo/KLScrollSelectDemo/KLViewController.m
@@ -12,6 +12,7 @@
 
 @end
 
+#define IOS_VERSION [[[UIDevice currentDevice] systemVersion] floatValue]
 @implementation KLViewController
 -(void) viewDidLoad {
     [super viewDidLoad];
@@ -54,9 +55,19 @@
 }
 - (UITableViewCell*) scrollSelect:(KLScrollSelect*) scrollSelect cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     KLScrollingColumn* column = [[scrollSelect columns] objectAtIndex: indexPath.column];
+    KLImageCell* cell;
     
-    [column registerClass:[KLImageCell class] forCellReuseIdentifier:@"Cell" ];
-    KLImageCell* cell = [column dequeueReusableCellWithIdentifier:@"Cell" forIndexPath:indexPath];
+    //registerClass only works on iOS 6 so if the app runs on iOS 5 we shouldn't use this method.
+    //On iOS 5 we only initialize a new KLImageCell if the cell is nil
+    if (IOS_VERSION >= 6.0) {
+        [column registerClass:[KLImageCell class] forCellReuseIdentifier:@"Cell" ];
+        cell = [column dequeueReusableCellWithIdentifier:@"Cell" forIndexPath:indexPath];
+    } else {
+        cell = [column dequeueReusableCellWithIdentifier:@"Cell"];
+        if (cell == nil) {
+            cell = [[KLImageCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"Cell"];
+        }
+    }
     
     [cell setSelectionStyle: UITableViewCellSelectionStyleNone];
     


### PR DESCRIPTION
@KieranLafferty

I wanted to use KLScrollSelect on iOS 5 but I couldn't do that.
There was two problems:
1- On iOS 5 we can't use registerClass it is introduced on iOS 6
2- On iOS 5 willMoveToSuperview method is called every time the cell is used or reused so initializing image in that method causes low performance scrolling

I changed KLScrollSelectDemo/KLViewController.m to resolve problem No. 1 and
KLScrollSelect/KLScrollSelect.m to resolve problem No. 2

Best Regards,
Nima Azimi
