### PR TITLE
Fix to orientation change drawing issues

### DIFF
--- a/KLScrollSelect/KLScrollSelect/KLScrollSelect.m
+++ b/KLScrollSelect/KLScrollSelect/KLScrollSelect.m
@@ -71,6 +71,11 @@
     [self synchronizeContentOffsetsWithDriver: self.driver];
 }
 -(void) populateColumns {
+    
+    for(KLScrollingColumn *column in self.columns){
+        [column removeFromSuperview];
+    }
+    
     NSInteger numberOfColumns = [self numberOfColumnsInScrollSelect:self];
     NSMutableArray* columns = [[NSMutableArray alloc] initWithCapacity:numberOfColumns];
     CGFloat columnWidth = self.frame.size.width/[self numberOfColumnsInScrollSelect:self];


### PR DESCRIPTION
removes old columns before drawing new ones in layoutSubviews:. 

This fixes an issue during orientation change, where columns would be drawn overlapping. 
